### PR TITLE
Modify the Event channnel to fix winodws nmi hung issue

### DIFF
--- a/pkg/nmi/server/server.go
+++ b/pkg/nmi/server/server.go
@@ -68,9 +68,8 @@ type NMIResponse struct {
 func NewServer(micNamespace string, blockInstanceMetadata bool, config *rest.Config) *Server {
 	clientSet := kubernetes.NewForConfigOrDie(config)
 	informer := informers.NewSharedInformerFactory(clientSet, 60*time.Second)
-	eventCh := make(chan aadpodid.EventType, 100)
 	podObjCh := make(chan *v1.Pod, 100)
-	podClient := pod.NewPodClientWithPodInfoCh(informer, eventCh, podObjCh)
+	podClient := pod.NewPodClientWithPodInfoCh(informer, podObjCh)
 
 	reporter, err := metrics.NewReporter()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping AAD Pod Identity with a pull request! -->

**Reason for Change**:
For now, if the windows nmi pod keeps running for 5 ~6 days, it starts to hung there and cannot capture any pod creation/deletion issue, which is because of the event channel is not used correctly.  I fixed the issue by modifying the event channel usage.


**Notes for Reviewers**:
